### PR TITLE
Fix storybook build by typescript version to 4.2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "jalaliday": "^2.3.0",
     "react-scripts": "4.0.1",
     "styled-components": "^5.1.0",
-    "typescript": "^4.0.3"
+    "typescript": "4.2.x"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
Due to https://github.com/storybookjs/storybook/issues/15067 storybook fails to build.

Work around this for now by pinning typescript to the version 4.2.x (the regression happens
in 4.3.x)

