### PR TITLE
Improve hover styling on rangePicker when spanning disabled days

### DIFF
--- a/src/rangePicker/Day.tsx
+++ b/src/rangePicker/Day.tsx
@@ -60,7 +60,7 @@ export const Day = ({
         : today;
   }
   let dateFormat = getDayFormat(day, jalali);
-  const handleDisabledDate = () => {
+  const isDisabledDate = (dateFormat: string) => {
     return (
       disabledDays.includes(dateFormat) ||
       (disabledBeforeDate && dayjs(dateFormat).isBefore(disabledBeforeDate)) ||
@@ -182,18 +182,15 @@ export const Day = ({
 
   // Handle style between of days
   const handleRangeStyle = () => {
-    if (!selectedDays?.from) {
-      return false;
-    }
-    if (selectedDays?.from) {
-      return dayjs(getDayFormat(day, jalali)).isBetween(
-        selectedDays.from,
-        getEndDateForClasses(),
-        null,
-        "[]",
-      );
-    }
-    return false;
+    if (!selectedDays || !selectedDays.from) return false;
+
+    // Always apply style to the start date
+    if (dateFormat === selectedDays.from) return true;
+
+    const end_date = getEndDateForClasses();
+    if (isDisabledDate(end_date)) return false;
+
+    return dayjs(dateFormat).isBetween(selectedDays.from, end_date, null, "[]");
   };
 
   const hoverOnDay = () => {
@@ -210,7 +207,7 @@ export const Day = ({
       onMouseEnter={hoverOnDay}
       className={classNames({
         inactive: day.month() !== source.add(numberOfMonth, "month").month(),
-        disabled: handleDisabledDate() && !handleRangeStyle(),
+        disabled: isDisabledDate(dateFormat) && !handleRangeStyle(),
         "range-select": handleRangeStyle(),
         jalali: jalali,
         disable: disabled,


### PR DESCRIPTION
When using disabledDaysSpan feature if you have selected a start date but then hover your mouse over a disabled date, the hover styles (range-select) will still be applied even although it's invalid.

This change only applies the range-select class if the hover day is a valid selection for an end date.

## How Has This Been Tested?

I've tested this in the Storybook build with existing stories. Note that when allowDisabledDaysSpan is not set, the hover behaviour remains unchanged and allows the hovers over the disabled days but when an end date is selected, the longest possible range  up until the first disabled day is still selected. I presume this is the expected and desirable interaction.

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
