### PR TITLE
fix: type imports now can pull in constants types from constants file

### DIFF
--- a/src/datePicker/datePicker.type.ts
+++ b/src/datePicker/datePicker.type.ts
@@ -1,4 +1,4 @@
-import { InitialComponents, InitialProps } from "constant";
+import { InitialComponents, InitialProps } from "../constant";
 
 export type DatePickerOnChange = (days: string[]) => void;
 

--- a/src/rangePicker/rangePicker.type.ts
+++ b/src/rangePicker/rangePicker.type.ts
@@ -1,4 +1,4 @@
-import { InitialComponents, InitialProps } from "constant";
+import { InitialComponents, InitialProps } from "../constant";
 
 export type RangePickerOnChange = (
   selectedDays: RangePickerSelectedDays,


### PR DESCRIPTION
Updated type definitions file to pull in constants via relative path

## Description

Right now when using range picker in my project I'm getting a typescript error when attempting to add the property `numberOfMonths`.  I think it's because it doesn't have the same `rollup.config.js`.  It can't follow the path to the config folder

## Motivation and Context
Right now I get a typescript error and have to use a `@ts-ignore` to avoid it

## How Has This Been Tested?
Once updating the relative path I no longer get a ts error.  Functionality does not change

## Screenshots (if appropriate):

## Types of changes
- [ x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
