### PR TITLE
More flexible styling

### DIFF
--- a/src/components/DisplayMonths.tsx
+++ b/src/components/DisplayMonths.tsx
@@ -37,7 +37,7 @@ export const DisplayMonths = ({
       );
     });
   };
-  return <Wrapper jalali={jalali}>{renderMonths()}</Wrapper>;
+  return <Wrapper className="tp-calendar-month-select" jalali={jalali}>{renderMonths()}</Wrapper>;
 };
 
 type StyleProps = {

--- a/src/components/DisplayYears.tsx
+++ b/src/components/DisplayYears.tsx
@@ -27,7 +27,7 @@ export const DisplayYears = ({ setDisplayYears, setSource }: Props) => {
     );
   }
 
-  return <Wrapper ref={ref}> {years} </Wrapper>;
+  return <Wrapper className="tp-calendar-year-select" ref={ref}> {years} </Wrapper>;
 };
 
 const Wrapper = styled.div`

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -96,6 +96,7 @@ export const Header = ({
 
   return (
     <Wrapper
+      className="tp-calendar-header"
       numberOfMonths={numberOfMonths}
       jalali={jalali}
       displayMonths={displayMonths}

--- a/src/components/TitleOfWeek.tsx
+++ b/src/components/TitleOfWeek.tsx
@@ -30,7 +30,7 @@ export const TitleOfWeek: React.FunctionComponent<Props> = ({
   }
 
   return (
-    <Wrapper jalali={jalali} startOfWeek={startOfWeek}>
+    <Wrapper className="tp-calendar-week-titles" jalali={jalali} startOfWeek={startOfWeek}>
       {titles.map(item => (
         <p key={item}>{item}</p>
       ))}

--- a/src/constant/types.ts
+++ b/src/constant/types.ts
@@ -1,5 +1,6 @@
 import { DefaultTheme } from "styled-components";
 import { ElementType, ReactNode } from "react";
+import { Dayjs } from "dayjs";
 
 type HeaderIconsPosition = {
   right: ReactNode;
@@ -35,6 +36,7 @@ export interface InitialProps {
   numberOfMonths?: number;
   initialMonthAndYear?: string;
   onRangeDateInScreen?: DatePickerWindowUpdated;
+  dayClasses?: (day: Dayjs) => string[];
 }
 
 type DatePickerWindow = { start: string; end: string };

--- a/src/datePicker/DatePicker.tsx
+++ b/src/datePicker/DatePicker.tsx
@@ -27,6 +27,7 @@ export const DatePicker = ({
   onChange,
   initialMonthAndYear,
   onRangeDateInScreen,
+  dayClasses,
 }: DatePickerProps) => {
   const [selectedDays, setSelectedDays] = useState(selectedDaysProps || []);
   const [numberOfMonths, setNumberOfMonths] = useState(numberOfMonthsProps);
@@ -129,6 +130,7 @@ export const DatePicker = ({
             disabledBeforeDate={disabledBeforeDate}
             disabledBeforeToday={disabledBeforeToday}
             numberOfSelectableDays={numberOfSelectableDays}
+            dayClasses={dayClasses}
           />
         )}
       </ThemeProvider>

--- a/src/datePicker/Day.tsx
+++ b/src/datePicker/Day.tsx
@@ -23,6 +23,7 @@ type Props = {
   components?: DatePickerComponents;
   onChange: DatePickerOnChange;
   setSelectedDays: Dispatch<SetStateAction<string[]>>;
+  dayClasses?: (day: Dayjs) => string[];
 };
 
 export const Day: React.FC<Props> = ({
@@ -40,6 +41,7 @@ export const Day: React.FC<Props> = ({
   numberOfSelectableDays,
   disabledBeforeDate,
   disabledAfterDate,
+  dayClasses,
 }) => {
   if (disabledBeforeToday) {
     const today = dayjs().format(FORMAT_DATE);
@@ -134,6 +136,10 @@ export const Day: React.FC<Props> = ({
   };
 
   const DayComponent = components?.days;
+  let extraDayClasses = "";
+  if (dayClasses) {
+    extraDayClasses = dayClasses(day).join(" ");
+  }
   return (
     <Wrapper
       data-test={day.format(FORMAT_DATE)}
@@ -147,7 +153,7 @@ export const Day: React.FC<Props> = ({
           dayjs()
             .calendar(jalali ? "jalali" : "gregory")
             .format(FORMAT_DATE) === day.format(FORMAT_DATE),
-      })}
+      }, extraDayClasses)}
     >
       {DayComponent && (
         <DayComponent day={day.format(FORMAT_DATE)} jalali={jalali} />

--- a/src/datePicker/Day.tsx
+++ b/src/datePicker/Day.tsx
@@ -153,7 +153,7 @@ export const Day: React.FC<Props> = ({
           dayjs()
             .calendar(jalali ? "jalali" : "gregory")
             .format(FORMAT_DATE) === day.format(FORMAT_DATE),
-      }, extraDayClasses)}
+      }, extraDayClasses, "tp-calendar-day")}
     >
       {DayComponent && (
         <DayComponent day={day.format(FORMAT_DATE)} jalali={jalali} />

--- a/src/datePicker/Months.tsx
+++ b/src/datePicker/Months.tsx
@@ -57,6 +57,7 @@ export const Months = ({
       );
       months.push(
         <Month
+          className="tp-calendar-month"
           numberOfMonths={numberOfMonths || 1}
           key={dayjs().set("month", 1).set("day", 1).diff(source, "d")}
           data-test={dayjs().set("month", 1).set("day", 1).diff(source, "d")}
@@ -68,6 +69,7 @@ export const Months = ({
           />
           {weeksDays.map(week => (
             <Weeks
+              className="tp-calendar-week"
               jalali={jalali}
               data-test={dayjs()
                 .set("month", 1)
@@ -102,5 +104,5 @@ export const Months = ({
     }
     return months;
   };
-  return <Wrapper jalali={jalali}>{renderMonths()}</Wrapper>;
+  return <Wrapper className="tp-calendar-months" jalali={jalali}>{renderMonths()}</Wrapper>;
 };

--- a/src/datePicker/Months.tsx
+++ b/src/datePicker/Months.tsx
@@ -24,6 +24,7 @@ interface Props {
   components?: DatePickerComponents;
   setSource: Dispatch<SetStateAction<Dayjs>>;
   setSelectedDays: Dispatch<SetStateAction<string[]>>;
+  dayClasses?: (day: Dayjs) => string[];
 }
 
 export const Months = ({
@@ -41,6 +42,7 @@ export const Months = ({
   disabled,
   onChange,
   source: sourceProp,
+  dayClasses,
 }: Props) => {
   const renderMonths = () => {
     let months = [];
@@ -90,6 +92,7 @@ export const Months = ({
                   disabledBeforeDate={disabledBeforeDate}
                   disabledAfterDate={disabledAfterDate}
                   numberOfSelectableDays={numberOfSelectableDays}
+                  dayClasses={dayClasses}
                 />
               ))}
             </Weeks>

--- a/src/rangePicker/Day.tsx
+++ b/src/rangePicker/Day.tsx
@@ -234,7 +234,7 @@ export const Day = ({
           dayjs()
             .calendar(jalali ? "jalali" : "gregory")
             .format(FORMAT_DATE) === day.format(FORMAT_DATE),
-      }, extraDayClasses)}
+      }, extraDayClasses, "tp-calendar-day")}
     >
       {DayComponent && (
         <DayComponent day={day.format(FORMAT_DATE)} jalali={jalali} />

--- a/src/rangePicker/Day.tsx
+++ b/src/rangePicker/Day.tsx
@@ -33,6 +33,7 @@ interface Props {
   setSelectedDays: Dispatch<
     SetStateAction<RangePickerSelectedDays | undefined>
   >;
+  dayClasses?: (day: Dayjs) => string[];
 }
 
 export const Day = ({
@@ -52,6 +53,7 @@ export const Day = ({
   disabledBeforeToday,
   disabledBeforeDate,
   disabledAfterDate,
+  dayClasses,
 }: Props) => {
   if (disabledBeforeToday) {
     const today = dayjs().format(FORMAT_DATE);
@@ -199,6 +201,10 @@ export const Day = ({
   };
 
   const DayComponent = components?.days;
+  let extraDayClasses = "";
+  if (dayClasses) {
+    extraDayClasses = dayClasses(day).join(" ");
+  }
   return (
     <Wrapper
       data-test={day.format(FORMAT_DATE)}
@@ -228,7 +234,7 @@ export const Day = ({
           dayjs()
             .calendar(jalali ? "jalali" : "gregory")
             .format(FORMAT_DATE) === day.format(FORMAT_DATE),
-      })}
+      }, extraDayClasses)}
     >
       {DayComponent && (
         <DayComponent day={day.format(FORMAT_DATE)} jalali={jalali} />

--- a/src/rangePicker/Months.tsx
+++ b/src/rangePicker/Months.tsx
@@ -68,6 +68,7 @@ export const Months = ({
       );
       months.push(
         <Month
+          className="tp-calendar-month"
           numberOfMonths={numberOfMonths || 1}
           key={dayjs().set("month", 1).set("day", 1).diff(source, "d")}
           data-test={dayjs().set("month", 1).set("day", 1).diff(source, "d")}
@@ -79,6 +80,7 @@ export const Months = ({
           />
           {weeksDays.map(week => (
             <Weeks
+              className="tp-calendar-week"
               jalali={jalali}
               data-test={dayjs()
                 .set("month", 1)
@@ -116,5 +118,5 @@ export const Months = ({
     return months;
   };
 
-  return <Wrapper jalali={jalali}>{renderMonths()}</Wrapper>;
+  return <Wrapper className="tp-calendar-months" jalali={jalali}>{renderMonths()}</Wrapper>;
 };

--- a/src/rangePicker/Months.tsx
+++ b/src/rangePicker/Months.tsx
@@ -33,6 +33,7 @@ interface Props {
   setSelectedDays: Dispatch<
     SetStateAction<RangePickerSelectedDays | undefined>
   >;
+  dayClasses?: (day: Dayjs) => string[];
 }
 
 export const Months = ({
@@ -52,6 +53,7 @@ export const Months = ({
   disabled,
   onChange,
   source: sourceProp,
+  dayClasses,
 }: Props) => {
   const renderMonths = () => {
     let months = [];
@@ -103,6 +105,7 @@ export const Months = ({
                   allowDisabledDaysSpan={allowDisabledDaysSpan}
                   disabledBeforeDate={disabledBeforeDate}
                   disabledAfterDate={disabledAfterDate}
+                  dayClasses={dayClasses}
                 />
               ))}
             </Weeks>

--- a/src/rangePicker/RangePicker.tsx
+++ b/src/rangePicker/RangePicker.tsx
@@ -27,6 +27,7 @@ export const RangePicker = ({
   onChange,
   initialMonthAndYear,
   onRangeDateInScreen,
+  dayClasses,
 }: RangePickerProps) => {
   const [selectedDays, setSelectedDays] = useState(selectedDaysProps);
   const [hoverDay, setHoverDay] = useState<string>();
@@ -130,6 +131,7 @@ export const RangePicker = ({
             disabledBeforeDate={disabledBeforeDate}
             disabledAfterDate={disabledAfterDate}
             allowDisabledDaysSpan={allowDisabledDaysSpan}
+            dayClasses={dayClasses}
           />
         )}
       </ThemeProvider>

--- a/src/stories/DatePicker.stories.tsx
+++ b/src/stories/DatePicker.stories.tsx
@@ -183,6 +183,23 @@ stories.add("Selected Days", () => {
   );
 });
 
+stories.add("Custom Day Classes", () => {
+  return (
+    <>
+      <style type="text/css">{`
+        .odd { transform: rotate(-10deg); } .even { transform: rotate(10deg); }
+      `}</style>
+      <DatePicker
+        numberOfMonths={1}
+        autoResponsive={false}
+        initialMonthAndYear="2021-08"
+        onChange={dates => window.console.log(dates)}
+        dayClasses={day => [parseInt(day.format('D')) % 2 == 1 ? 'odd' : 'even' ]}
+      />
+    </>
+  );
+});
+
 stories.add("Number of Selectable Days", () => {
   return (
     <DatePicker

--- a/src/stories/RangePicker.stories.tsx
+++ b/src/stories/RangePicker.stories.tsx
@@ -215,6 +215,23 @@ stories.add("Allow Disabled Days Span", () => {
   );
 });
 
+stories.add("Custom Day Classes", () => {
+  return (
+    <>
+      <style type="text/css">{`
+        .odd { transform: rotate(-10deg); } .even { transform: rotate(10deg); }
+      `}</style>
+      <RangePicker
+        numberOfMonths={1}
+        autoResponsive={false}
+        initialMonthAndYear="2021-08"
+        onChange={dates => window.console.log(dates)}
+        dayClasses={day => [parseInt(day.format('D')) % 2 == 1 ? 'odd' : 'even' ]}
+      />
+    </>
+  );
+});
+
 stories.add("Custom components - Title of weeks Component", () => {
   return (
     <RangePicker


### PR DESCRIPTION
## Description

These changes allow for more flexible styling

## Motivation and Context

We're using the calendar to select start and end dates for holiday bookings (unsurprisingly!)

At present the calendar only has a single "invalid" class for dates that cannot be selected. This is generally fine but for better UX, we may wish to differentiate days that are not technically sold out, but perhaps don't meed certain rules. e.g. a given property may only allow check-in's on Saturdays. All other days of the week are invalid for selection but that doesn't mean they are sold out. 

But allowing a callback which can be used to apply custom class names to the days, we can allow great downstream flexibility.

I've also added some more generic classes to the various objects. This allows for general purpose styling without having to override the components.

## How Has This Been Tested?

I have written a storybook entry for this change which adds the odd or even class to each day and a little inline style to see this in action.

I have also incorporated this into another project which uses it in a more complex way.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
