### PR TITLE
chore: point homepage at samsam-ahmadi.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 - 📐 Auto-responsive multi-month layout (via `ResizeObserver`)
 - 🪶 ESM-first, tree-shakable, sourcemaps included
 
-[Storybook & live docs →](https://killthejs.com/react-trip-date/)
+[Storybook & live docs →](https://samsam-ahmadi.com/react-trip-date/)
 
 ## Install
 
@@ -70,14 +70,14 @@ import { Calendar } from "react-trip-date";
 
 Full prop tables and live examples in Storybook:
 
-- [DatePicker](https://killthejs.com/react-trip-date/?path=/docs/components-datepicker--docs)
-- [RangePicker](https://killthejs.com/react-trip-date/?path=/docs/components-rangepicker--docs)
-- [Calendar](https://killthejs.com/react-trip-date/?path=/docs/components-calendar--docs)
-- [Theming](https://killthejs.com/react-trip-date/?path=/docs/docs-theming--docs)
-- [Localization](https://killthejs.com/react-trip-date/?path=/docs/docs-localization--docs)
-- [Accessibility & keyboard nav](https://killthejs.com/react-trip-date/?path=/docs/docs-accessibility--docs)
-- [Recipes](https://killthejs.com/react-trip-date/?path=/docs/docs-recipes--docs)
-- [Migration v1 → v2](https://killthejs.com/react-trip-date/?path=/docs/docs-migration-v1-%E2%86%92-v2--docs)
+- [DatePicker](https://samsam-ahmadi.com/react-trip-date/?path=/docs/components-datepicker--docs)
+- [RangePicker](https://samsam-ahmadi.com/react-trip-date/?path=/docs/components-rangepicker--docs)
+- [Calendar](https://samsam-ahmadi.com/react-trip-date/?path=/docs/components-calendar--docs)
+- [Theming](https://samsam-ahmadi.com/react-trip-date/?path=/docs/docs-theming--docs)
+- [Localization](https://samsam-ahmadi.com/react-trip-date/?path=/docs/docs-localization--docs)
+- [Accessibility & keyboard nav](https://samsam-ahmadi.com/react-trip-date/?path=/docs/docs-accessibility--docs)
+- [Recipes](https://samsam-ahmadi.com/react-trip-date/?path=/docs/docs-recipes--docs)
+- [Migration v1 → v2](https://samsam-ahmadi.com/react-trip-date/?path=/docs/docs-migration-v1-%E2%86%92-v2--docs)
 
 ## Develop
 

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "bugs": {
     "url": "https://github.com/samsam-ahmadi/react-trip-date/issues"
   },
-  "homepage": "https://killthejs.com/react-trip-date/",
+  "homepage": "https://samsam-ahmadi.com/react-trip-date/",
   "keywords": [
     "react",
     "date",


### PR DESCRIPTION
Move the docs site host from killthejs.com to samsam-ahmadi.com.

- package.json `homepage` field.
- 9 deep-link URLs in the README (top hero link and the eight /docs/* entries under "API").

No content change; URL paths after the host are unchanged so the Storybook story IDs still resolve.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
