### PR TITLE
ci(pages): serialize storybook deploys to avoid duplicate artifacts

### DIFF
--- a/.github/workflows/storybook.yml
+++ b/.github/workflows/storybook.yml
@@ -14,6 +14,14 @@ permissions:
   pages: write
   id-token: write
 
+# Allow only one Pages deploy at a time. If a new push happens while a
+# previous deploy is still running, cancel that one — otherwise both
+# uploads write the same `github-pages` artifact and deploy-pages fails
+# with "Multiple artifacts named 'github-pages' were unexpectedly found".
+concurrency:
+  group: pages
+  cancel-in-progress: true
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Two concurrent runs of the Storybook deploy each upload an artifact named "github-pages", and `actions/deploy-pages` then fails with "Multiple artifacts named 'github-pages' were unexpectedly found for this workflow run. Artifact count is 2."

Add a concurrency block with `group: pages` and
`cancel-in-progress: true` so a new push cancels the older deploy before it can upload — the workflow run that survives is always the only one with an artifact.

This is also the pattern recommended in the GitHub Pages deploy example, so it doubles as alignment with the canonical workflow.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
