### PR TITLE
ci(commitlint): allow long body/footer lines for semantic-release bots

### DIFF
--- a/commitlint.config.mjs
+++ b/commitlint.config.mjs
@@ -1,1 +1,20 @@
-export default { extends: ["@commitlint/config-conventional"] };
+/**
+ * Inherits the conventional-commits rules with two overrides:
+ *
+ *   body-max-line-length / footer-max-line-length — semantic-release's
+ *   `@semantic-release/git` plugin commits the bumped package.json +
+ *   CHANGELOG.md with a body that quotes the changelog entry, and the
+ *   entry always contains a GitHub commit URL longer than 100
+ *   characters. Without disabling these rules, the husky commit-msg
+ *   hook rejects every bot release commit and the publish workflow
+ *   fails at the very last step.
+ *
+ *   `0` = level disabled. Keep the rest of conventional-commits intact.
+ */
+export default {
+  extends: ["@commitlint/config-conventional"],
+  rules: {
+    "body-max-line-length": [0, "always"],
+    "footer-max-line-length": [0, "always"],
+  },
+};


### PR DESCRIPTION
The publish workflow reached the very last step — `git commit` of the bumped package.json + CHANGELOG.md done by `@semantic-release/git` — and got rejected by our husky commit-msg hook with:

  body's lines must not be longer than 100 characters
  [body-max-line-length]

The offending line is a GitHub commit URL embedded in the auto-generated changelog body. semantic-release's release notes always include such URLs and they're always longer than 100 chars, so every bot release commit would hit this.

Override the two rules. Conventional-commits enforcement on subject
+ type + scope is preserved; only the body/footer hard wrap is relaxed, which is consistent with how every project running semantic-release configures commitlint.

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
